### PR TITLE
Auth: authentification sing-in et sign-up

### DIFF
--- a/.github/workflows/setup-repo.yml
+++ b/.github/workflows/setup-repo.yml
@@ -74,4 +74,3 @@ jobs:
             }
 
             console.log(`\n📊 Summary: ${closedCount} closed, ${createdCount} created`);
-

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <NConfigProvider>
     <NMessageProvider>
       <NLayout>
-        <HeaderBar />
+        <HeaderBar v-if="authStore.isAuthenticated" />
         <NLayoutContent>
           <RouterView />
         </NLayoutContent>
@@ -13,6 +13,9 @@
 
 <script setup lang="ts">
 import HeaderBar from './components/layout/HeaderBar.vue'
+import { useAuthStore } from './store/auth'
+
+const authStore = useAuthStore()
 </script>
 
 <style>

--- a/src/components/layout/HeaderBar.vue
+++ b/src/components/layout/HeaderBar.vue
@@ -26,13 +26,25 @@
         </NButton>
       </NSpace>
       <NSpace align="center" :size="16">
-        <NText depth="3">Renseigner le user connecté ici</NText>
-        <NButton size="small">Déconnexion</NButton>
+        <NText depth="3">{{ authStore.user?.username }}</NText>
+        <NButton size="small" @click="handleLogout">Déconnexion</NButton>
       </NSpace>
     </NSpace>
   </NLayoutHeader>
 </template>
 
 <script setup lang="ts">
+import { useRouter } from 'vue-router'
+
+import { ROUTES } from '../../router'
+import { useAuthStore } from '../../store/auth'
+
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL as string
+const router = useRouter()
+const authStore = useAuthStore()
+
+const handleLogout = () => {
+  authStore.logout()
+  router.push(ROUTES.SIGNIN)
+}
 </script>

--- a/src/pages/SignInPage.vue
+++ b/src/pages/SignInPage.vue
@@ -1,0 +1,103 @@
+<template>
+  <div class="sign-in-page">
+    <NCard title="Connexion" style="max-width: 400px; margin: 80px auto">
+      <NForm ref="formRef" :model="formData" :rules="rules">
+        <NFormItem label="Email" path="email">
+          <NInput
+            v-model:value="formData.email"
+            type="email"
+            placeholder="votre@email.com"
+            @keyup.enter="handleSignIn"
+          />
+        </NFormItem>
+        <NFormItem label="Mot de passe" path="password">
+          <NInput
+            v-model:value="formData.password"
+            type="password"
+            placeholder="••••••••"
+            show-password-on="click"
+            @keyup.enter="handleSignIn"
+          />
+        </NFormItem>
+        <NSpace vertical :size="12">
+          <NButton
+            type="primary"
+            block
+            :loading="loading"
+            @click="handleSignIn"
+          >
+            Se connecter
+          </NButton>
+          <NText depth="3" style="text-align: center; display: block">
+            Pas encore de compte ?
+            <RouterLink to="/signup">S'inscrire</RouterLink>
+          </NText>
+        </NSpace>
+      </NForm>
+    </NCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { FormInst, FormRules } from 'naive-ui'
+import { useMessage } from 'naive-ui'
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { useApi } from '../composables/useApi'
+import { useAuthStore } from '../store/auth'
+import type { SignInPayload } from '../types/auth'
+
+const router = useRouter()
+const message = useMessage()
+const authStore = useAuthStore()
+const api = useApi()
+
+const formRef = ref<FormInst | null>(null)
+const loading = ref(false)
+
+const formData = ref<SignInPayload>({
+  email: '',
+  password: '',
+})
+
+const rules: FormRules = {
+  email: [
+    { required: true, message: 'Email requis', trigger: 'blur' },
+    { type: 'email', message: 'Email invalide', trigger: 'blur' },
+  ],
+  password: [
+    { required: true, message: 'Mot de passe requis', trigger: 'blur' },
+    { min: 6, message: 'Au moins 6 caractères', trigger: 'blur' },
+  ],
+}
+
+const handleSignIn = async () => {
+  await formRef.value?.validate(async (errors) => {
+    if (errors) return
+
+    loading.value = true
+    try {
+      const response = await api.signIn(formData.value)
+      authStore.login(response.token, response.user)
+      message.success(`Bienvenue ${response.user.username} !`)
+      router.push('/')
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Erreur de connexion'
+      message.error(errorMessage)
+    } finally {
+      loading.value = false
+    }
+  })
+}
+</script>
+
+<style scoped>
+.sign-in-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/src/pages/SignUpPage.vue
+++ b/src/pages/SignUpPage.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="sign-up-page">
+    <NCard title="Inscription" style="max-width: 400px; margin: 80px auto">
+      <NForm ref="formRef" :model="formData" :rules="rules">
+        <NFormItem label="Nom d'utilisateur" path="username">
+          <NInput
+            v-model:value="formData.username"
+            placeholder="votre_pseudo"
+            @keyup.enter="handleSignUp"
+          />
+        </NFormItem>
+        <NFormItem label="Email" path="email">
+          <NInput
+            v-model:value="formData.email"
+            type="email"
+            placeholder="votre@email.com"
+            @keyup.enter="handleSignUp"
+          />
+        </NFormItem>
+        <NFormItem label="Mot de passe" path="password">
+          <NInput
+            v-model:value="formData.password"
+            type="password"
+            placeholder="••••••••"
+            show-password-on="click"
+            @keyup.enter="handleSignUp"
+          />
+        </NFormItem>
+        <NSpace vertical :size="12">
+          <NButton
+            type="primary"
+            block
+            :loading="loading"
+            @click="handleSignUp"
+          >
+            S'inscrire
+          </NButton>
+          <NText depth="3" style="text-align: center; display: block">
+            Déjà un compte ?
+            <RouterLink to="/signin">Se connecter</RouterLink>
+          </NText>
+        </NSpace>
+      </NForm>
+    </NCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { FormInst, FormRules } from 'naive-ui'
+import { useMessage } from 'naive-ui'
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { useApi } from '../composables/useApi'
+import { useAuthStore } from '../store/auth'
+import type { SignUpPayload } from '../types/auth'
+
+const router = useRouter()
+const message = useMessage()
+const authStore = useAuthStore()
+const api = useApi()
+
+const formRef = ref<FormInst | null>(null)
+const loading = ref(false)
+
+const formData = ref<SignUpPayload>({
+  username: '',
+  email: '',
+  password: '',
+})
+
+const rules: FormRules = {
+  username: [
+    { required: true, message: "Nom d'utilisateur requis", trigger: 'blur' },
+    { min: 3, message: 'Au moins 3 caractères', trigger: 'blur' },
+  ],
+  email: [
+    { required: true, message: 'Email requis', trigger: 'blur' },
+    { type: 'email', message: 'Email invalide', trigger: 'blur' },
+  ],
+  password: [
+    { required: true, message: 'Mot de passe requis', trigger: 'blur' },
+    { min: 6, message: 'Au moins 6 caractères', trigger: 'blur' },
+  ],
+}
+
+const handleSignUp = async () => {
+  await formRef.value?.validate(async (errors) => {
+    if (errors) return
+
+    loading.value = true
+    try {
+      const response = await api.signUp(formData.value)
+      authStore.login(response.token, response.user)
+      message.success(`Compte créé ! Bienvenue ${response.user.username} !`)
+      router.push('/')
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Erreur lors de l'inscription"
+      message.error(errorMessage)
+    } finally {
+      loading.value = false
+    }
+  })
+}
+</script>
+
+<style scoped>
+.sign-up-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,18 +1,43 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
 import HomePage from './pages/HomePage.vue'
+import SignInPage from './pages/SignInPage.vue'
+import SignUpPage from './pages/SignUpPage.vue'
+import { useAuthStore } from './store/auth'
 
 export const ROUTES = {
   HOME: '/',
+  SIGNIN: '/signin',
+  SIGNUP: '/signup',
 } as const
 
 const routes = [
   { path: ROUTES.HOME, component: HomePage, meta: { requiresAuth: true } },
+  { path: ROUTES.SIGNIN, component: SignInPage, meta: { requiresGuest: true } },
+  { path: ROUTES.SIGNUP, component: SignUpPage, meta: { requiresGuest: true } },
 ]
 
 const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+// Router guard pour gérer l'authentification (RG2 et RG3)
+router.beforeEach((to, _from, next) => {
+  const authStore = useAuthStore()
+  const isAuthenticated = authStore.isAuthenticated
+
+  // RG2: Route privée nécessite authentification
+  if (to.meta.requiresAuth && !isAuthenticated) {
+    return next(ROUTES.SIGNIN)
+  }
+
+  // RG3: Pages de connexion/inscription inaccessibles si déjà connecté
+  if (to.meta.requiresGuest && isAuthenticated) {
+    return next(ROUTES.HOME)
+  }
+
+  next()
 })
 
 export default router

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,32 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+import { useStorage } from '../composables/useStorage'
+import type { User } from '../types'
+
+const storage = useStorage()
+
+export const useAuthStore = defineStore('auth', () => {
+  // État — initialisé depuis le localStorage si disponible
+  const token = ref<string | null>(storage.get<string>('token'))
+  const user = ref<User | null>(storage.get<User>('user'))
+
+  // Getter
+  const isAuthenticated = computed(() => !!token.value)
+
+  // Actions
+  const login = (newToken: string, newUser: User): void => {
+    token.value = newToken
+    user.value = newUser
+    storage.set('token', newToken)
+    storage.set('user', newUser)
+  }
+
+  const logout = (): void => {
+    token.value = null
+    user.value = null
+    storage.remove('token', 'user')
+  }
+
+  return { token, user, isAuthenticated, login, logout }
+})


### PR DESCRIPTION
> Contenu de l'issue [#2 — 1. Authentification (3 pts)](https://github.com/FrozenRoy/tgc-spa-dehame/issues/2)

Mettre en place le système d'authentification complet : store, guards de navigation et pages de connexion/inscription.

> 🎨 [Voir les maquettes sur Figma](https://making-rerun-61323218.figma.site/)

---

## Store d'authentification

L'application doit gérer un état de connexion global, persisté entre les rechargements de page. Cet état contient le token JWT et les informations de l'utilisateur connecté.

La navigation doit être protégée : un utilisateur non connecté est redirigé vers la page de connexion s'il tente d'accéder à une route privée, et un utilisateur déjà connecté ne peut pas accéder aux pages de connexion ou d'inscription. La barre de navigation n'est visible que pour les utilisateurs connectés.

> La protection des routes implique également de modifier le fichier `router.ts` en y ajoutant un router guard.



### Règles de gestion

| #   | Règle                                                                                           |
| --- | ----------------------------------------------------------------------------------------------- |
| RG1 | L'état de connexion (token + informations utilisateur) est persisté et restauré au rechargement |
| RG2 | Toute route privée redirige vers la page de connexion si l'utilisateur n'est pas authentifié    |
| RG3 | Les pages de connexion et d'inscription sont inaccessibles si l'utilisateur est déjà connecté   |
| RG4 | La barre de navigation n'est affichée que si l'utilisateur est connecté                         |
| RG5 | La barre de navigation affiche le nom d'utilisateur connecté                                    |
| RG6 | La barre de navigation propose un bouton de déconnexion qui redirige vers la page de connexion  |

---

## Page de connexion

Page accessible aux utilisateurs non connectés. L'utilisateur saisit son email et son mot de passe. En cas de succès, il est redirigé vers la page d'accueil (`/`). En cas d'échec, un message d'erreur s'affiche. Un lien permet d'accéder à la page d'inscription.


### Règles de gestion

| #   | Règle                                                                     |
| --- | ------------------------------------------------------------------------- |
| RG1 | Le formulaire contient les champs email et mot de passe                   |
| RG2 | Le bouton de soumission est désactivé pendant l'appel à l'API             |
| RG3 | Un message d'erreur s'affiche si les identifiants sont incorrects         |
| RG4 | L'utilisateur est redirigé vers la page d'accueil après connexion réussie |
| RG5 | Un lien vers la page d'inscription est visible                            |

---

## Page d'inscription

Page accessible aux utilisateurs non connectés. L'utilisateur saisit un nom d'utilisateur, un email et un mot de passe. En cas de succès, il est redirigé vers la page d'accueil (`/`). En cas d'échec (ex. email déjà utilisé), un message d'erreur s'affiche. Un lien permet d'accéder à la page de connexion.


### Règles de gestion

| #   | Règle                                                                       |
| --- | --------------------------------------------------------------------------- |
| RG1 | Le formulaire contient les champs username, email et mot de passe           |
| RG2 | Le bouton de soumission est désactivé pendant l'appel à l'API               |
| RG3 | Un message d'erreur s'affiche en cas d'échec de l'inscription               |
| RG4 | L'utilisateur est redirigé vers la page d'accueil après inscription réussie |
| RG5 | Un lien vers la page de connexion est visible                               |

---

---

Closes #2