### PR TITLE
feat(recherche): Ajout de la recherche de pokemon

### DIFF
--- a/src/components/CardGrid.vue
+++ b/src/components/CardGrid.vue
@@ -10,6 +10,7 @@
       v-for="card in cards"
       :key="card.id"
       :card="card"
+      :current-hp="card.hp"
       :size="size"
       :selected="selectable && selectedIds.includes(card.id)"
       :disabled="selectable && isDisabled(card.id)"

--- a/src/components/DeckList.vue
+++ b/src/components/DeckList.vue
@@ -33,6 +33,7 @@
             <PokemonCard
               v-if="cardMap[deckCard.cardId]"
               :card="cardMap[deckCard.cardId]"
+              :current-hp="cardMap[deckCard.cardId].hp"
               size="sm"
             />
           </template>

--- a/src/components/PokemonCard.vue
+++ b/src/components/PokemonCard.vue
@@ -96,7 +96,7 @@ const props = withDefaults(
     size?: 'sm' | 'md'
     selected?: boolean
     disabled?: boolean
-    currentHp?: number
+    currentHp: number
   }>(),
   { size: 'md', selected: false, disabled: false },
 )

--- a/src/pages/DeckFormPage.vue
+++ b/src/pages/DeckFormPage.vue
@@ -24,15 +24,22 @@
             Chargement des cartes...
           </div>
 
-          <CardGrid
-            v-else
-            :cards="allCards"
-            size="sm"
-            :selectable="true"
-            :max-selected="10"
-            :selected-ids="selectedCardIds"
-            @update:selected-ids="selectedCardIds = $event"
-          />
+          <div v-else style="width: 100%">
+            <NInput
+              v-model:value="search"
+              placeholder="Rechercher une carte par nom..."
+              clearable
+              style="margin-bottom: 12px"
+            />
+            <CardGrid
+              :cards="filteredCards"
+              size="sm"
+              :selectable="true"
+              :max-selected="10"
+              :selected-ids="selectedCardIds"
+              @update:selected-ids="selectedCardIds = $event"
+            />
+          </div>
         </NFormItem>
       </NForm>
 
@@ -71,10 +78,20 @@ const isEdit = computed(() => !!route.params.id)
 const deckId = computed(() => route.params.id as string)
 
 const name = ref('')
+const search = ref('')
 const selectedCardIds = ref<number[]>([])
 const allCards = ref<Card[]>([])
 const loadingCards = ref(false)
 const submitting = ref(false)
+
+const filteredCards = computed(() => {
+  const q = search.value.trim().toLowerCase()
+  if (!q) return allCards.value
+  return allCards.value.filter(
+    (c) =>
+      c.name.toLowerCase().includes(q) || selectedCardIds.value.includes(c.id),
+  )
+})
 
 const isValid = computed(
   () => name.value.trim().length > 0 && selectedCardIds.value.length === 10,


### PR DESCRIPTION
> Contenu de l'issue [#5 — 4. Barre de recherche dans le formulaire de deck (2 pts)](https://github.com/FrozenRoy/tgc-spa-dehame/issues/5)

Un champ de recherche au-dessus de la grille de cartes permet de filtrer les cartes par nom en temps réel. Les cartes déjà sélectionnées restent sélectionnées même si elles ne correspondent pas à la recherche.

> 🎨 [Voir les maquettes sur Figma](https://making-rerun-61323218.figma.site/)


### Règles de gestion

| #   | Règle                                                                                  |
| --- | -------------------------------------------------------------------------------------- |
| RG1 | Un champ de recherche est affiché au-dessus de la grille de cartes                     |
| RG2 | La grille est filtrée en temps réel selon le texte saisi (par nom de carte)            |
| RG3 | Une carte déjà sélectionnée reste sélectionnée même si elle est filtrée hors de la vue |

---

---

Closes #5